### PR TITLE
Fix season nostats

### DIFF
--- a/__tests__/components/LatestSeasonRanking.test.tsx
+++ b/__tests__/components/LatestSeasonRanking.test.tsx
@@ -8,13 +8,35 @@ import userEvent from "@testing-library/user-event";
 import LatestSeasonRanking, {
   LatestSeasonRankingProps,
 } from "@/components/LatestSeasonRanking";
+import { GetLatestSeasonQuery } from "graphql/generated/queryTypes";
+
+const mockSeasonObject: GetLatestSeasonQuery["latestSeason"] = {
+  id: "1",
+  startDate: "2022-05-15T12:00:00Z",
+  playerStats: [
+    {
+      __typename: "SeasonPlayerStats",
+      playerId: "1",
+      firstName: "John",
+      lastName: "Doe",
+      image: "www.image.com",
+      matches: [],
+    },
+  ],
+};
+
+const mockNoStatSeasonObject: GetLatestSeasonQuery["latestSeason"] = {
+  id: "1",
+  startDate: "2022-05-15T12:00:00Z",
+  playerStats: [],
+};
 
 describe("LatestSeasonRanking", () => {
   it("displays tendency ranking when rankType = tendency", () => {
     const props: LatestSeasonRankingProps = {
       handleRankingType: jest.fn(),
       rankingType: "tendency",
-      season: { id: "1", startDate: "2022-05-15T12:00:00Z", playerStats: [] },
+      season: mockSeasonObject,
     };
 
     render(<LatestSeasonRanking {...props} />);
@@ -33,7 +55,7 @@ describe("LatestSeasonRanking", () => {
     const props: LatestSeasonRankingProps = {
       handleRankingType: jest.fn(),
       rankingType: "average",
-      season: { id: "1", startDate: "2022-05-15T12:00:00Z", playerStats: [] },
+      season: mockSeasonObject,
     };
 
     render(<LatestSeasonRanking {...props} />);
@@ -52,7 +74,7 @@ describe("LatestSeasonRanking", () => {
     const props: LatestSeasonRankingProps = {
       handleRankingType: jest.fn(),
       rankingType: "award",
-      season: { id: "1", startDate: "2022-05-15T12:00:00Z", playerStats: [] },
+      season: mockSeasonObject,
     };
 
     render(<LatestSeasonRanking {...props} />);
@@ -72,7 +94,7 @@ describe("LatestSeasonRanking", () => {
     const props: LatestSeasonRankingProps = {
       handleRankingType: mockHandler,
       rankingType: "tendency",
-      season: { id: "1", startDate: "2022-05-15T12:00:00Z", playerStats: [] },
+      season: mockSeasonObject,
     };
 
     render(<LatestSeasonRanking {...props} />);
@@ -104,5 +126,17 @@ describe("LatestSeasonRanking", () => {
       expect(mockHandler).toHaveBeenCalledTimes(3);
       expect(mockHandler).toHaveBeenCalledWith("award");
     });
+  });
+
+  it("renders a message when season has no stats", async () => {
+    const mockHandler = jest.fn();
+    const props: LatestSeasonRankingProps = {
+      handleRankingType: mockHandler,
+      rankingType: "tendency",
+      season: mockNoStatSeasonObject,
+    };
+
+    render(<LatestSeasonRanking {...props} />);
+    expect(screen.getByTestId("no-stats")).toBeInTheDocument();
   });
 });

--- a/components/LatestSeasonRanking/index.tsx
+++ b/components/LatestSeasonRanking/index.tsx
@@ -36,11 +36,27 @@ const LatestSeasonRanking = ({
         handleRankingType={handleRankingType}
       />
 
-      <div className="flex-1 overflow-scroll scroll-hide">
-        {rankingType === "average" && <LatestSeasonAvgRanking stats={stats} />}
-        {rankingType === "tendency" && <LatestSeasonTdcRanking stats={stats} />}
-        {rankingType === "award" && <LatestSeasonAwardRanking stats={stats} />}
-      </div>
+      {stats.length ? (
+        <div className="flex-1 overflow-scroll scroll-hide">
+          {rankingType === "average" && (
+            <LatestSeasonAvgRanking stats={stats} />
+          )}
+          {rankingType === "tendency" && (
+            <LatestSeasonTdcRanking stats={stats} />
+          )}
+          {rankingType === "award" && (
+            <LatestSeasonAwardRanking stats={stats} />
+          )}
+        </div>
+      ) : (
+        <div className="flex justify-center w-full h-full p-2 mt-1 bg-white rounded dark:bg-dark-500 drop-shadow-sm">
+          <div className="flex items-center justify-center w-full px-2 py-4 rounded-sm dark:bg-dark-300 bg-marine-50 h-fit">
+            <span className="text-xs" data-testid="no-stats">
+              Pas encore de stats cette saison.
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/pages/matches/index.tsx
+++ b/pages/matches/index.tsx
@@ -174,7 +174,7 @@ const MatchesPage = () => {
       }
 
       if (!selectedSeason) {
-        const latestSeason = seasons.sort((a, b) =>
+        const latestSeason = [...seasons].sort((a, b) =>
           new Date(a.startDate) < new Date(b.startDate) ? 1 : -1
         )[0];
 
@@ -360,7 +360,7 @@ const MatchesPage = () => {
         />
       </div>
 
-      {router.query.shape === "chart" && communityChartStats ? (
+      {router.query.shape === "chart" && communityChartStats?.length ? (
         <div className="flex-1 w-full pb-8 mt-8 overflow-scroll scroll-hide">
           <div className="flex flex-col w-full grid-cols-2 gap-4 lg:grid">
             <VisxChartContainer title="Moyenne de chaque match de la saison">
@@ -455,7 +455,7 @@ const MatchesPage = () => {
           {communityStats.length === 0 && (
             <div className="flex items-center justify-center mt-4">
               <div className="flex flex-col items-center justify-center w-full p-4 text-center border rounded bg-marine-100 border-marine-200 text-marine-400 md:p-8 dark:bg-marine-900/10 dark:border-marine-400">
-                <p>Aucun match disponible avec ces critères.</p>
+                <p>Aucune statistique ne correspond à ces critères.</p>
               </div>
             </div>
           )}

--- a/pages/players/[playerId].tsx
+++ b/pages/players/[playerId].tsx
@@ -422,7 +422,13 @@ const PlayerPage = () => {
         }
         toggleLocation={toggleLocation}
         competitions={competitions}
-        seasons={seasons}
+        seasons={
+          seasons
+            ? seasons.filter((s) =>
+                s.players.some((p) => p.playerId === playerId)
+              )
+            : undefined
+        }
         currentCompetitionId={
           competitions?.find((c) => router.query.competition === c.abbreviation)
             ?.id || "all"

--- a/pages/players/index.tsx
+++ b/pages/players/index.tsx
@@ -190,7 +190,7 @@ const PlayersPage = () => {
       }
 
       if (!selectedSeason) {
-        const latestSeason = seasons.sort((a, b) =>
+        const latestSeason = [...seasons].sort((a, b) =>
           new Date(a.startDate) < new Date(b.startDate) ? 1 : -1
         )[0];
 
@@ -323,7 +323,7 @@ const PlayersPage = () => {
 
   // init player IDS to show in chart
   useEffect(() => {
-    if (communityChartStats && idsToShow.length === 0) {
+    if (communityChartStats?.length && idsToShow.length === 0) {
       const sortedPlayersByNumberOfMatches = communityChartStats.sort((a, b) =>
         a.numberOfMatchesPlayed > b.numberOfMatchesPlayed ? -1 : 1
       );
@@ -396,7 +396,7 @@ const PlayersPage = () => {
         />
       </div>
 
-      {router.query.shape === "chart" && communityChartStats ? (
+      {router.query.shape === "chart" && communityChartStats?.length ? (
         <div className="flex py-8 overflow-hidden scroll-hide gap-x-8">
           <div className="flex flex-col flex-grow overflow-x-hidden overflow-y-scroll gap-y-8">
             <VisxChartContainer title="Moyenne des joueurs pour chaque match de la saison.">
@@ -489,7 +489,7 @@ const PlayersPage = () => {
           />
         </div>
       ) : (
-        <div className="flex justify-center w-full md:py-8">
+        <div className="flex flex-col justify-center w-full md:py-8">
           <Draggable>
             <PlayersTable
               data={
@@ -499,6 +499,14 @@ const PlayersPage = () => {
               }
             />
           </Draggable>
+
+          {communityStats.length === 0 && (
+            <div className="flex items-center justify-center mt-4">
+              <div className="flex flex-col items-center justify-center w-full p-4 text-center border rounded bg-marine-100 border-marine-200 text-marine-400 md:p-8 dark:bg-marine-900/10 dark:border-marine-400">
+                <p>Aucune statistique ne correspond à ces critères.</p>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
- fix errors on players/matches pages when current season had no stats, with better conditional rendering.
- ffor player page, the season filter only shows seasons where current player played in.
- show message in LatestSeasonRanking when current season has no stats yet (so cant make a ranking yet)